### PR TITLE
Remove key transformation

### DIFF
--- a/lib/icasework/case.rb
+++ b/lib/icasework/case.rb
@@ -12,8 +12,10 @@ module Icasework
         Icasework::Resource.get_cases(params).data.map do |data|
           new(
             case_details: {
-              case_id: data[:case_id], case_type: data[:case_type],
-              case_label: data[:case_label], rating: data[:rating]
+              case_id: data['CaseId'],
+              case_type: data['CaseType'],
+              case_label: data['CaseLabel'],
+              rating: data['Rating']
             }
           )
         end
@@ -21,7 +23,7 @@ module Icasework
 
       def create(params)
         data = Icasework::Resource.create_case(params).data
-        new(case_details: { case_id: data[:createcaseresponse][:caseid] })
+        new(case_details: { case_id: data['createcaseresponse']['caseid'] })
       end
     end
 

--- a/lib/icasework/resource.rb
+++ b/lib/icasework/resource.rb
@@ -92,43 +92,15 @@ module Icasework
 
     def prepare_payload(payload)
       return unless payload
-
-      # TODO: handle array values, map keys suffixed with integers
-      payload[:format] = 'json' if @include_format
-      payload.transform_keys! do |k|
-        next k if valid_keys.include?(k.to_s)
-
-        k.to_s.classify
-      end
-
+      payload['Format'] = 'json' if @include_format
       payload
-    end
-
-    # these params keys should remain as they are, no need to classify-case them
-    def valid_keys
-      %w[db fromseq toseq grant_type assertion access_token]
     end
 
     def parser
       lambda do |response, _request, _result|
-        process_data(JSON.parse(response.body))
+        JSON.parse(response.body)
       rescue JSON::ParserError
         raise ResponseError, "JSON invalid (#{response.body[0...100]})"
-      end
-    end
-
-    def process_data(data)
-      case data
-      when Hash
-        data.deep_transform_keys! do |key|
-          # TODO: handle keys suffixed with integers, map to arrays
-          # TODO: handle keys with periods, map to hashes
-          key.underscore.to_sym
-        end
-      when Array
-        data.map { |d| process_data(d) }
-      else
-        data
       end
     end
   end

--- a/lib/icasework/token/bearer.rb
+++ b/lib/icasework/token/bearer.rb
@@ -24,6 +24,7 @@ module Icasework
       end
 
       def initialize(data)
+        data = data.dup.symbolize_keys!
         @access_token = data.fetch(:access_token)
         @token_type = data.fetch(:token_type)
         @expires_in = data.fetch(:expires_in)

--- a/spec/icasework/case_spec.rb
+++ b/spec/icasework/case_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Icasework::Case do
 
     let(:uri) { 'https://uatportal.icasework.com/getcases' }
     let(:response) { { status: 200, body: [].to_json } }
-    let(:payload) { { type: 'InformationRequest' } }
+    let(:payload) { { 'Type' => 'InformationRequest' } }
     let(:token) do
       Icasework::Token::Bearer.new(
         { access_token: 'mock_token', token_type: 'bearer', expires_in: 3600 }
@@ -23,7 +23,7 @@ RSpec.describe Icasework::Case do
     it 'calls the GET getcases endpoint with payload' do
       cases
       expect(WebMock).to have_requested(:get, "#{uri}?db=test").with(
-        query: { Format: 'json', Type: 'InformationRequest' }
+        query: { 'Format' => 'json', 'Type' => 'InformationRequest' }
       ).once
     end
 
@@ -45,7 +45,7 @@ RSpec.describe Icasework::Case do
       { status: 200, body: { createcaseresponse: { caseid: 123 } }.to_json }
     end
     let(:payload) do
-      { format: 'json', type: 'InformationRequest' }
+      { 'Format' => 'json', 'Type' => 'InformationRequest' }
     end
     let(:token) do
       Icasework::Token::Bearer.new(

--- a/spec/icasework/resource_spec.rb
+++ b/spec/icasework/resource_spec.rb
@@ -130,30 +130,17 @@ RSpec.describe Icasework::Resource do
 
       it 'add JSON format param' do
         expect(WebMock).to have_requested(:get, uri).with(
-          query: { Format: 'json' }
+          query: { 'Format' => 'json' }
         ).once
       end
     end
 
     context 'with payload' do
-      let(:payload) { { foo: 'bar' } }
+      let(:payload) { { 'Foo' => 'bar' } }
 
-      it 'transforms payload keys to classify-case' do
+      it 'submits payload keys' do
         expect(WebMock).to have_requested(:get, uri).with(
-          query: { Foo: 'bar' }
-        ).once
-      end
-    end
-
-    context 'with payload which should not be transformed' do
-      let(:payload) do
-        { db: 'db', fromseq: 0, toseq: 10, grant_type: 'grant_type',
-          assertion: 'assertion', access_token: 'access_token' }
-      end
-
-      it 'does not transforms payload keys' do
-        expect(WebMock).to have_requested(:get, uri).with(
-          query: payload
+          query: { 'Foo' => 'bar' }
         ).once
       end
     end
@@ -184,7 +171,7 @@ RSpec.describe Icasework::Resource do
       it 'add JSON format param' do
         expect(WebMock).to have_requested(:post, uri).with(
           headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
-          body: { Format: 'json' }
+          body: { 'Format' => 'json' }
         ).once
       end
     end
@@ -195,32 +182,18 @@ RSpec.describe Icasework::Resource do
       it 'add JSON format param' do
         expect(WebMock).to have_requested(:post, uri).with(
           headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
-          body: { Format: 'json' }
+          body: { 'Format' => 'json' }
         ).once
       end
     end
 
     context 'with payload' do
-      let(:payload) { { foo: 'bar' } }
+      let(:payload) { { 'Foo' => 'bar' } }
 
-      it 'transforms payload keys to classify-case' do
+      it 'submits payload keys' do
         expect(WebMock).to have_requested(:post, uri).with(
           headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
-          body: { Foo: 'bar' }
-        ).once
-      end
-    end
-
-    context 'with payload which should not be transformed' do
-      let(:payload) do
-        { db: 'db', fromseq: 0, toseq: 10, grant_type: 'grant_type',
-          assertion: 'assertion', access_token: 'access_token' }
-      end
-
-      it 'does not transforms payload keys' do
-        expect(WebMock).to have_requested(:post, uri).with(
-          headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
-          body: payload
+          body: { 'Foo' => 'bar' }
         ).once
       end
     end

--- a/spec/icasework/token/bearer_spec.rb
+++ b/spec/icasework/token/bearer_spec.rb
@@ -66,9 +66,9 @@ RSpec.describe Icasework::Token::Bearer do
   shared_context 'with instance' do
     let(:mock_data) do
       {
-        access_token: 'token',
-        token_type: 'bearer',
-        expires_in: 3600
+        'access_token' => 'token',
+        'token_type' => 'bearer',
+        'expires_in' => 3600
       }
     end
 


### PR DESCRIPTION
Currently isn't fully compatible, so simplifying for immediate usage.

* Need to submit "Customer.Name", which is currently unsupported
* `classify` corrupts keys – it transforms "Details" to "Detail"

Can now create cases using the key formatting expected by the API:

    data = { 'RequestMethod' => 'Online Form',
             'Type' => 'InformationRequest',
             'Customer.Name' => 'x',
             'Customer.Email' => 'x@example.com',
             'Details' => 'My foi request…' }
    result = Icasework::Case.create(data)
    # => #<Icasework::Case:0x00007ff3f763cb38
           @data={:case_details=>{:case_id=>"491234"}}>

Also removes key transformation of responses. We're mapping to nicer
keys when creating `Icasework::Case` instances, so it doesn't seem
necessary to have a further translation layer.

Also fixes #4. 