### PR TITLE
Switch to XML API responses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     icasework (0.1.0)
       activesupport (>= 4.0.0)
       jwt (~> 2.2.0)
+      nokogiri (~> 1.0)
       rest-client (~> 2.1.0)
 
 GEM
@@ -36,8 +37,12 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
+    mini_portile2 (2.5.0)
     minitest (5.14.4)
     netrc (0.11.0)
+    nokogiri (1.11.2)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
@@ -45,6 +50,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.6)
+    racc (1.5.2)
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.1.1)

--- a/icasework.gemspec
+++ b/icasework.gemspec
@@ -34,5 +34,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 4.0.0'
   spec.add_dependency 'jwt', '~> 2.2.0'
+  spec.add_dependency 'nokogiri', '~> 1.0'
   spec.add_dependency 'rest-client', '~> 2.1.0'
 end

--- a/lib/icasework/case.rb
+++ b/lib/icasework/case.rb
@@ -7,12 +7,14 @@ module Icasework
   class Case
     class << self
       def where(params)
-        Icasework::Resource.get_cases(params).data.map do |data|
+        Icasework::Resource.get_cases(params).data['Cases']['Case'].map do |d|
           new(
-            'CaseDetails.CaseId' => data['CaseId'],
-            'CaseDetails.CaseType' => data['CaseType'],
-            'CaseDetails.CaseLabel' => data['CaseLabel'],
-            'CaseDetails.Rating' => data['Rating']
+            'CaseDetails.CaseId' => d['CaseId'],
+            'CaseDetails.CaseType' => d['Type'],
+            'CaseDetails.CaseLabel' => d['Label'],
+            'CaseStatusReceipt.Method' => d['RequestMethod'],
+            'CaseStatusReceipt.TimeCreated' => d['RequestDate'],
+            'CaseStatus.Status' => d['Status']
           )
         end
       end

--- a/spec/fixtures/createcase_success.txt
+++ b/spec/fixtures/createcase_success.txt
@@ -1,7 +1,5 @@
 HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
-Content-Length: 48
+Content-Type: text/xml;charset=UTF-8
+Content-Length: 122
 
-{"createcaseresponse": {
-  "caseid": "489834"
-}}
+<?xml version="1.0" encoding="UTF-8"?><createcaseresponse><caseid>492233</caseid><team>INBOXIR</team></createcaseresponse>

--- a/spec/fixtures/getcases_success.txt
+++ b/spec/fixtures/getcases_success.txt
@@ -1,27 +1,53 @@
 HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
-Content-Length: 511
+content-type: text/xml;charset=UTF-8
+content-length: 2790
 
-[
-{
-"CaseId": "487347",
-"CaseType": "Information request",
-"CaseLabel": "IR - y",
-"ContactMethod": "Online Form",
-"DateReceived": "2021-02-15",
-"TimeCreated": "2021-02-15T16:42:19",
-"Status": "Some information sent but not all held",
-"Rating": "Standard"
-}
-,
-{
-"CaseId": "487342",
-"CaseType": "Information request",
-"CaseLabel": "IR - h",
-"ContactMethod": "Email",
-"DateReceived": "2021-02-15",
-"TimeCreated": "2021-02-15T16:39:18",
-"Status": "All information sent",
-"Rating": "Standard"
-}
-]
+<?xml version="1.0" encoding="UTF-8"?>
+<Cases>
+  <Case>
+    <CaseId>487347</CaseId>
+    <Type>Information request</Type>
+    <Label>IR - y</Label>
+    <RequestMethod>Online Form</RequestMethod>
+    <RequestDate>2021-02-15T16:42:19</RequestDate>
+    <Status>Some information sent but not all held</Status>
+    <Attributes>
+      <Details>y</Details>
+      <InformationWillBe>Embedded in the response</InformationWillBe>
+      <PublishInTheDisclosureLog>Yes</PublishInTheDisclosureLog>
+      <ReasonInformationNotHeld>t</ReasonInformationNotHeld>
+      <SuitableForPublicationScheme>Yes</SuitableForPublicationScheme>
+    </Attributes>
+    <Classifications>
+      <Classification Group="About the council">Budgets spending and performance</Classification>
+      <Classification Group="Licensing and regulation">Animal licensing</Classification>
+      <Classification Group="Leisure and culture">Libraries</Classification>
+    </Classifications>
+    <Documents>
+      <Document Id="D225851" Name="Response (some not held)" Category="General upload" Type="application/pdf" Source="Document" DocumentDate="2021-02-15T16:43:11"><![CDATA[https://uatportal.icasework.com/servlet/servlets.getImg?ref=D225851&bin=Y&auth=0&db=UJzFimNH5H4%3D&access_token=773WgblkSUxU7tva_uAQRK77bUD4lDfgfes_mz3uPHwZNu3ucP5OXsYgCtvDCvYz.AJAhd9_B7RiK45ojg4Lilw%3D%3D]]></Document>
+    </Documents>
+  </Case>
+  <Case>
+    <CaseId>487342</CaseId>
+    <Type>Information request</Type>
+    <Label>IR - h</Label>
+    <RequestMethod>Email</RequestMethod>
+    <RequestDate>2021-02-15T16:39:18</RequestDate>
+    <Status>All information sent</Status>
+    <Attributes>
+      <Details>h</Details>
+      <InformationWillBe>Embedded in the response</InformationWillBe>
+      <PublishInTheDisclosureLog>Yes</PublishInTheDisclosureLog>
+      <SuitableForPublicationScheme>Yes</SuitableForPublicationScheme>
+    </Attributes>
+    <Classifications>
+      <Classification Group="About the council">Budgets spending and performance</Classification>
+      <Classification Group="Children and families">Adoption and fostering</Classification>
+      <Classification Group="Health and social care">Adult social care</Classification>
+      <Classification Group="Transport and streets">Cycling</Classification>
+    </Classifications>
+    <Documents>
+      <Document Id="D225945" Name="Response (all information to be supplied)" Category="General upload" Type="application/pdf" Source="Document" DocumentDate="2021-02-15T16:40:18"><![CDATA[https://uatportal.icasework.com/servlet/servlets.getImg?ref=D225945&bin=Y&auth=0&db=UJzFimNH5H4%3D&access_token=8dfWG2lEfUtFVO5kf9DAW3bfDYjPdAc8Uy8WBnKoZFBFl6aY7YtbMaCHXFWznd9S.B3IF9gqOYDhq9ceqHFTVWw%3D%3D]]></Document>
+    </Documents>
+  </Case>
+</Cases>

--- a/spec/icasework/case_spec.rb
+++ b/spec/icasework/case_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Icasework::Case do
     subject(:cases) { described_class.where(payload) }
 
     let(:uri) { 'https://uatportal.icasework.com/getcases' }
-    let(:response) { { status: 200, body: [].to_json } }
     let(:payload) { { 'Type' => 'InformationRequest' } }
     let(:token) do
       Icasework::Token::Bearer.new(
@@ -18,7 +17,9 @@ RSpec.describe Icasework::Case do
 
     before do
       allow(Icasework::Token::Bearer).to receive(:generate).and_return(token)
-      stub_request(:get, /#{uri}.*/).to_return(response)
+      stub_request(:get, /#{uri}.*/).to_return(
+        File.new('spec/fixtures/getcases_success.txt')
+      )
     end
 
     it 'calls the GET getcases endpoint with payload' do
@@ -29,10 +30,6 @@ RSpec.describe Icasework::Case do
     end
 
     context 'when successful' do
-      let(:response) do
-        File.new('spec/fixtures/getcases_success.txt')
-      end
-
       it { is_expected.to be_an Array }
       it { is_expected.to all(be_an(described_class)) }
     end
@@ -42,9 +39,6 @@ RSpec.describe Icasework::Case do
     subject(:create_case) { described_class.create(payload) }
 
     let(:uri) { 'https://uat.icasework.com/createcase' }
-    let(:response) do
-      { status: 200, body: { createcaseresponse: { caseid: 123 } }.to_json }
-    end
     let(:payload) { { 'Type' => 'InformationRequest' } }
     let(:token) do
       Icasework::Token::Bearer.new(
@@ -55,7 +49,9 @@ RSpec.describe Icasework::Case do
 
     before do
       allow(Icasework::Token::Bearer).to receive(:generate).and_return(token)
-      stub_request(:post, /#{uri}.*/).to_return(response)
+      stub_request(:post, /#{uri}.*/).to_return(
+        File.new('spec/fixtures/createcase_success.txt')
+      )
     end
 
     it 'calls the POST createcase endpoint with payload' do
@@ -67,10 +63,6 @@ RSpec.describe Icasework::Case do
     end
 
     context 'when successful' do
-      let(:response) do
-        File.new('spec/fixtures/createcase_success.txt')
-      end
-
       it { is_expected.to be_an described_class }
     end
   end

--- a/spec/icasework/case_spec.rb
+++ b/spec/icasework/case_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Icasework::Case do
     it 'calls the GET getcases endpoint with payload' do
       cases
       expect(WebMock).to have_requested(:get, "#{uri}?db=test").with(
-        query: { 'Format' => 'json', 'Type' => 'InformationRequest' }
+        query: { 'Format' => 'xml', 'Type' => 'InformationRequest' }
       ).once
     end
 
@@ -58,7 +58,7 @@ RSpec.describe Icasework::Case do
       create_case
       expect(WebMock).to have_requested(:post, "#{uri}?db=test").with(
         headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
-        body: { 'Format' => 'json', 'Type' => 'InformationRequest' }
+        body: { 'Format' => 'xml', 'Type' => 'InformationRequest' }
       ).once
     end
 

--- a/spec/icasework/resource_spec.rb
+++ b/spec/icasework/resource_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Icasework::Resource do
     context 'when POST request, with format option' do
       let(:method) { :post }
 
-      it { is_expected.to eq(Format: 'json', Foo: 'bar') }
+      it { is_expected.to eq(Format: 'xml', Foo: 'bar') }
     end
 
     context 'when POST request, without format option' do
@@ -171,7 +171,7 @@ RSpec.describe Icasework::Resource do
     context 'when GET request, with format option' do
       let(:method) { :get }
 
-      it { is_expected.to eq(params: { Format: 'json', Foo: 'bar' }) }
+      it { is_expected.to eq(params: { Format: 'xml', Foo: 'bar' }) }
     end
 
     context 'when GET request, without format option' do


### PR DESCRIPTION
This returns more information on the `getcases` endpoint such as case classifications.