### PR TITLE
Add processing of payload and returned data

### DIFF
--- a/lib/icasework.rb
+++ b/lib/icasework.rb
@@ -9,6 +9,8 @@ module Icasework
   require 'icasework/case'
   require 'icasework/errors'
   require 'icasework/resource'
+  require 'icasework/resource/data'
+  require 'icasework/resource/payload'
   require 'icasework/token/jwt'
   require 'icasework/token/bearer'
 

--- a/lib/icasework/case.rb
+++ b/lib/icasework/case.rb
@@ -7,21 +7,37 @@ module Icasework
   class Case
     class << self
       def where(params)
-        Icasework::Resource.get_cases(params).data['Cases']['Case'].map do |d|
+        Icasework::Resource.get_cases(params).data[:cases][:case].map do |data|
           new(
-            'CaseDetails.CaseId' => d['CaseId'],
-            'CaseDetails.CaseType' => d['Type'],
-            'CaseDetails.CaseLabel' => d['Label'],
-            'CaseStatusReceipt.Method' => d['RequestMethod'],
-            'CaseStatusReceipt.TimeCreated' => d['RequestDate'],
-            'CaseStatus.Status' => d['Status']
+            case_details: case_details_data(data),
+            case_status: case_status_data(data),
+            case_status_receipt: case_status_receipt_data(data)
           )
         end
       end
 
       def create(params)
         data = Icasework::Resource.create_case(params).data
-        new('CaseDetails.CaseId' => data['createcaseresponse']['caseid'])
+        new(
+          case_details: {
+            case_id: data[:createcaseresponse][:caseid]
+          }
+        )
+      end
+
+      private
+
+      def case_details_data(data)
+        { case_id: data[:case_id], case_type: data[:type],
+          case_label: data[:label] }
+      end
+
+      def case_status_receipt_data(data)
+        { method: data[:request_method], time_created: data[:request_date] }
+      end
+
+      def case_status_data(data)
+        { status: data[:status] }
       end
     end
 
@@ -30,7 +46,7 @@ module Icasework
     end
 
     def case_id
-      @data['CaseDetails.CaseId']
+      @data[:case_details][:case_id]
     end
   end
 end

--- a/lib/icasework/resource.rb
+++ b/lib/icasework/resource.rb
@@ -63,8 +63,9 @@ module Icasework
     def payload
       return @payload if @payload_parsed
 
-      @payload[:Format] = format if format
+      @payload[:format] = format if format
 
+      @payload = Payload.process(@payload)
       @payload = { params: @payload } if method == :get
 
       @payload_parsed = true
@@ -97,7 +98,7 @@ module Icasework
 
     def parser
       lambda do |response, _request, _result|
-        parse_format(response)
+        Data.process(parse_format(response))
       rescue JSON::ParserError
         raise ResponseError, "JSON invalid (#{response.body[0...100]})"
       rescue REXML::ParseException

--- a/lib/icasework/resource/data.rb
+++ b/lib/icasework/resource/data.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Icasework
+  class Resource
+    ##
+    # Converts data returned from the iCasework API into a more "Ruby like" hash
+    #
+    module Data
+      class << self
+        def process(data)
+          case data
+          when Hash
+            convert_keys(array_keys_to_array(flat_keys_to_nested(data)))
+          when Array
+            data.map { |d| process(d) }
+          else
+            data
+          end
+        end
+
+        private
+
+        # converts: { 'foo.bar': 'baz' }
+        # into { foo: { bar: 'baz' } }
+        def flat_keys_to_nested(hash)
+          hash.each_with_object({}) do |(key, value), all|
+            key_parts = key.to_s.split('.')
+            leaf = key_parts[0...-1].inject(all) { |h, k| h[k] ||= {} }
+            leaf[key_parts.last] = process(value)
+          end
+        end
+
+        # converts: { 'n1': 'foo', 'n2': 'bar' }
+        # into: { n: ['foo', 'bar'] }
+        def array_keys_to_array(hash)
+          hash.each_with_object({}) do |(key, value), all|
+            if key.to_s =~ /^(.*)\d+$/
+              key = Regexp.last_match(1)
+              all[key] ||= []
+              all[key] << process(value)
+            else
+              all[key] = process(value)
+            end
+          end
+        end
+
+        # converts: 'FooBar'
+        # into: :foo_bar
+        def convert_keys(hash)
+          hash.each_with_object({}) do |(key, value), all|
+            converted_key = key.gsub(/([a-z\d])?([A-Z])/) do
+              first = Regexp.last_match(1)
+              second = Regexp.last_match(2)
+              "#{"#{first}_" if first}#{second.downcase}"
+            end
+
+            all[converted_key.to_sym] = process(value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/icasework/resource/payload.rb
+++ b/lib/icasework/resource/payload.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Icasework
+  class Resource
+    ##
+    # Converts payload for iCasework API endpoints into a flat/titlecase keys
+    #
+    module Payload
+      class << self
+        def process(data)
+          case data
+          when Hash
+            nested_to_flat_keys(convert_keys(data))
+          else
+            data
+          end
+        end
+
+        private
+
+        # converts { 'foo' => { 'bar' => 'baz' } }
+        # into: { 'foo.bar' => 'baz' }
+        def nested_to_flat_keys(hash, key = [])
+          return { key.join('.') => process(hash) } unless hash.is_a?(Hash)
+
+          hash.inject({}) do |h, v|
+            h.merge!(nested_to_flat_keys(v[-1], key + [v[0]]))
+          end
+        end
+
+        # converts: :foo_bar
+        # into: 'FooBar'
+        def convert_keys(hash)
+          hash.each_with_object({}) do |(key, value), all|
+            converted_key = key if valid_keys.include?(key.to_s)
+            converted_key ||= key.to_s.gsub(/(?:^|_)([a-z])/i) do
+              Regexp.last_match(1).upcase
+            end
+
+            all[converted_key.to_s] = process(value)
+          end
+        end
+
+        def valid_keys
+          %w[db fromseq toseq grant_type assertion access_token]
+        end
+      end
+    end
+  end
+end

--- a/lib/icasework/token/bearer.rb
+++ b/lib/icasework/token/bearer.rb
@@ -24,9 +24,9 @@ module Icasework
       end
 
       def initialize(data)
-        @access_token = data.fetch('access_token')
-        @token_type = data.fetch('token_type')
-        @expires_in = data.fetch('expires_in')
+        @access_token = data.fetch(:access_token)
+        @token_type = data.fetch(:token_type)
+        @expires_in = data.fetch(:expires_in)
       end
 
       def to_s

--- a/spec/icasework/case_spec.rb
+++ b/spec/icasework/case_spec.rb
@@ -5,8 +5,7 @@ require 'spec_helper'
 RSpec.describe Icasework::Case do
   let(:token) do
     Icasework::Token::Bearer.new(
-      { 'access_token' => 'mock_token', 'token_type' => 'bearer',
-        'expires_in' => 3600 }
+      { access_token: 'mock_token', token_type: 'bearer', expires_in: 3600 }
     )
   end
 
@@ -18,7 +17,7 @@ RSpec.describe Icasework::Case do
     subject(:cases) { described_class.where(payload) }
 
     let(:uri) { 'https://uatportal.icasework.com/getcases' }
-    let(:payload) { { 'Type' => 'InformationRequest' } }
+    let(:payload) { { type: 'InformationRequest' } }
 
     before do
       stub_request(:get, /#{uri}.*/).to_return(
@@ -44,7 +43,7 @@ RSpec.describe Icasework::Case do
     subject(:create_case) { described_class.create(payload) }
 
     let(:uri) { 'https://uat.icasework.com/createcase' }
-    let(:payload) { { 'Type' => 'InformationRequest' } }
+    let(:payload) { { type: 'InformationRequest' } }
 
     before do
       stub_request(:post, /#{uri}.*/).to_return(
@@ -68,7 +67,7 @@ RSpec.describe Icasework::Case do
   describe '#case_id' do
     subject { instance.case_id }
 
-    let(:instance) { described_class.new('CaseDetails.CaseId' => 123) }
+    let(:instance) { described_class.new(case_details: { case_id: 123 }) }
 
     it { is_expected.to eq 123 }
   end

--- a/spec/icasework/resource/data_spec.rb
+++ b/spec/icasework/resource/data_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Icasework::Resource::Data do
+  describe '.process' do
+    subject { described_class.process(data) }
+
+    let(:data) do
+      {
+        'Cases' => {
+          'Case' => {
+            'CaseDetails.CaseId' => 123,
+            'Event1.Foo' => 'Foo 1',
+            'Event1.Bar' => 'Bar 1',
+            'Event2.Foo' => 'Foo 2',
+            'Event2.Bar' => 'Bar 2',
+            'Keyword1' => 'foo',
+            'Keyword2' => 'bar',
+            'Object1' => { foo: 'Foo' },
+            'Object2' => { bar: 'Bar' }
+          }
+        }
+      }
+    end
+
+    let(:converted) do
+      {
+        cases: {
+          case: {
+            case_details: { case_id: 123 },
+            event: [
+              { foo: 'Foo 1', bar: 'Bar 1' },
+              { foo: 'Foo 2', bar: 'Bar 2' }
+            ],
+            keyword: %w[foo bar],
+            object: [
+              { foo: 'Foo' },
+              { bar: 'Bar' }
+            ]
+          }
+        }
+      }
+    end
+
+    it { is_expected.to eq(converted) }
+  end
+end

--- a/spec/icasework/resource/payload_spec.rb
+++ b/spec/icasework/resource/payload_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Icasework::Resource::Payload do
+  describe '.process' do
+    subject(:payload) { described_class.process(data) }
+
+    let(:data) do
+      {
+        customer: { email: 'alice@localhost', name: 'Alice' },
+        type: 'Information Request'
+      }
+    end
+
+    let(:converted) do
+      {
+        'Customer.Email' => 'alice@localhost',
+        'Customer.Name' => 'Alice',
+        'Type' => 'Information Request'
+      }
+    end
+
+    it { is_expected.to eq(converted) }
+
+    context 'with valid keys' do
+      let(:data) do
+        {
+          db: 'test',
+          fromseq: 0,
+          toseq: 10,
+          grant_type: 'bearer',
+          assertion: 'jwt',
+          access_token: 'token'
+        }
+      end
+
+      it 'does not convert case of the keys' do
+        expect(payload).to eq(
+          'db' => 'test', 'fromseq' => 0, 'toseq' => 10,
+          'grant_type' => 'bearer', 'assertion' => 'jwt',
+          'access_token' => 'token'
+        )
+      end
+    end
+  end
+end

--- a/spec/icasework/resource_spec.rb
+++ b/spec/icasework/resource_spec.rb
@@ -152,40 +152,40 @@ RSpec.describe Icasework::Resource do
     let(:method) { nil }
     let(:options) { {} }
     let(:instance) do
-      described_class.new(method, '', { Foo: 'bar' }, **options)
+      described_class.new(method, '', { foo: 'bar' }, **options)
     end
 
     context 'when POST request, with format option' do
       let(:method) { :post }
 
-      it { is_expected.to eq(Format: 'xml', Foo: 'bar') }
+      it { is_expected.to eq('Format' => 'xml', 'Foo' => 'bar') }
     end
 
     context 'when POST request, without format option' do
       let(:method) { :post }
       let(:options) { { format: nil } }
 
-      it { is_expected.to eq(Foo: 'bar') }
+      it { is_expected.to eq('Foo' => 'bar') }
     end
 
     context 'when GET request, with format option' do
       let(:method) { :get }
 
-      it { is_expected.to eq(params: { Format: 'xml', Foo: 'bar' }) }
+      it { is_expected.to eq(params: { 'Format' => 'xml', 'Foo' => 'bar' }) }
     end
 
     context 'when GET request, without format option' do
       let(:method) { :get }
       let(:options) { { format: nil } }
 
-      it { is_expected.to eq(params: { Foo: 'bar' }) }
+      it { is_expected.to eq(params: { 'Foo' => 'bar' }) }
     end
   end
 
   describe '#data' do
     let(:method) { nil }
     let(:instance) do
-      described_class.new(method, '', { Foo: 'bar' })
+      described_class.new(method, '', { 'Foo' => 'bar' })
     end
 
     before do

--- a/spec/icasework/token/bearer_spec.rb
+++ b/spec/icasework/token/bearer_spec.rb
@@ -66,9 +66,9 @@ RSpec.describe Icasework::Token::Bearer do
   shared_context 'with instance' do
     let(:mock_data) do
       {
-        'access_token' => 'token',
-        'token_type' => 'bearer',
-        'expires_in' => 3600
+        access_token: 'token',
+        token_type: 'bearer',
+        expires_in: 3600
       }
     end
 


### PR DESCRIPTION
This change allows us to use lowercase/underscored symbol keys for
payload and returned data from the API.