### PR TITLE
[#11] Add Icasework::Case#to_hash

### DIFF
--- a/lib/icasework/case.rb
+++ b/lib/icasework/case.rb
@@ -60,6 +60,10 @@ module Icasework
       @hash[key]
     end
 
+    def to_hash
+      @hash
+    end
+
     private
 
     def load_additional_data!

--- a/spec/icasework/case_spec.rb
+++ b/spec/icasework/case_spec.rb
@@ -110,4 +110,12 @@ RSpec.describe Icasework::Case do
       end
     end
   end
+
+  describe '#to_hash' do
+    subject { instance.to_hash }
+
+    let(:instance) { described_class.new(case_details: { case_id: 123 }) }
+
+    it { is_expected.to eq(case_details: { case_id: 123 }) }
+  end
 end


### PR DESCRIPTION
Returns all the attributes as a Hash.

Went for `to_hash` over `to_h` because the Rails convention is to use
the latter to return a `ActiveSupport::HashWithIndifferentAccess`.

Fixes #11 