### PR TITLE
Return XML tag attributes

### DIFF
--- a/lib/icasework.rb
+++ b/lib/icasework.rb
@@ -14,6 +14,7 @@ module Icasework
   require 'icasework/resource/payload'
   require 'icasework/token/jwt'
   require 'icasework/token/bearer'
+  require 'icasework/xml_converter'
 
   ConfigurationError = Class.new(StandardError)
 

--- a/lib/icasework/resource.rb
+++ b/lib/icasework/resource.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rest_client'
-require 'active_support/core_ext/hash/conversions'
 
 module Icasework
   ##
@@ -109,7 +108,7 @@ module Icasework
     def parse_format(response)
       case format
       when 'xml'
-        Hash.from_xml(response.body)
+        XMLConverter.new(response.body).to_h
       else
         JSON.parse(response.body)
       end

--- a/lib/icasework/xml_converter.rb
+++ b/lib/icasework/xml_converter.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/hash/conversions'
+
+module Icasework
+  ##
+  # A patched version of ActiveSupport's XML converter which includes XML tag
+  # attributes
+  #
+  # Credit: https://stackoverflow.com/a/29431089
+  #
+  class XMLConverter < ActiveSupport::XMLConverter
+    private
+
+    def become_content?(value)
+      value['type'] == 'file' ||
+        (value['__content__'] &&
+         (value.keys.size == 1 && value['__content__'].present?))
+    end
+  end
+end

--- a/spec/icasework/xml_converter_spec.rb
+++ b/spec/icasework/xml_converter_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Icasework::XMLConverter do
+  let(:instance) { described_class.new(xml) }
+
+  let(:xml) do
+    <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <Documents>
+        <Document Id="D123" Name="Response (some not held)" Category="General upload" Type="application/pdf" Source="Document" DocumentDate="2021-03-01T00:00:00"><![CDATA[https://example.com/file.pdf]]></Document>
+      </Documents>
+    XML
+  end
+
+  describe '#to_h' do
+    subject(:hash) { instance.to_h }
+
+    let(:expected) do
+      {
+        'Documents' => {
+          'Document' => {
+            'Category' => 'General upload',
+            'DocumentDate' => '2021-03-01T00:00:00',
+            'Id' => 'D123',
+            'Name' => 'Response (some not held)',
+            'Source' => 'Document',
+            'Type' => 'application/pdf',
+            '__content__' => 'https://example.com/file.pdf'
+          }
+        }
+      }
+    end
+
+    it 'converts XML into Ruby hash with tag attributes' do
+      expect(hash).to eq expected
+    end
+  end
+end


### PR DESCRIPTION
ActiveSupport::XMLConverter doesn't return tag attributes EG:
  `<Document name="blah">content</Document>`

Previously we would just get:
  `{"Document"=>"content"}`

Now with this change we now get:
  `{"Document"=>{"name"=>"blah", "__content__"=>"content"}}`

Connected to #12 