### PR TITLE
[#18] Fix Icasework::Case.where when no cases returned

### DIFF
--- a/lib/icasework/case.rb
+++ b/lib/icasework/case.rb
@@ -9,7 +9,10 @@ module Icasework
   class Case
     class << self
       def where(params)
-        Icasework::Resource.get_cases(params).data[:cases][:case].map do |data|
+        cases =
+          Array(Icasework::Resource.get_cases(params).data.dig(:cases, :case))
+
+        cases.map do |data|
           new(
             case_details: case_details_data(data),
             case_status: case_status_data(data),

--- a/spec/fixtures/getcases_empty.txt
+++ b/spec/fixtures/getcases_empty.txt
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+content-type: text/xml;charset=UTF-8
+content-length: 2790
+
+<?xml version="1.0" encoding="UTF-8"?>
+<Cases />

--- a/spec/icasework/case_spec.rb
+++ b/spec/icasework/case_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe Icasework::Case do
       it { is_expected.to all(be_an(described_class)) }
       it { expect(cases.count).to eq 2 }
     end
+
+    context 'when no cases returned' do
+      before do
+        stub_request(:get, /#{uri}.*/).to_return(
+          File.new('spec/fixtures/getcases_empty.txt')
+        )
+      end
+
+      it { is_expected.to be_an Array }
+      it { expect(cases.count).to eq 0 }
+    end
   end
 
   describe '.create' do


### PR DESCRIPTION
When there are no cases returned through the API:

    Icasework::Case.where(from: '1970-01-01', until: '2021-03-24', type: 'InformationRequest')
    # => NoMethodError: undefined method `[]' for nil:NilClass
    # => from /Users/gareth/src/mysociety/icasework-ruby/lib/icasework/case.rb:12:in `where' `

This makes sure we're not failing on empty Hash keys and always mapping
over an Array.

Fixes https://github.com/mysociety/icasework-ruby/issues/18