### PR TITLE
Update case data handling

### DIFF
--- a/lib/icasework/case.rb
+++ b/lib/icasework/case.rb
@@ -30,8 +30,8 @@ module Icasework
           case_status: case_status_data(data),
           case_status_receipt: case_status_receipt_data(data),
           attributes: data[:attributes],
-          classifications: [data[:classifications][:classification]].flatten,
-          documents: [data[:documents][:document]].flatten
+          classifications: case_classifications_data(data),
+          documents: case_documents_data(data)
         }
       end
 
@@ -46,6 +46,18 @@ module Icasework
 
       def case_status_data(data)
         { status: data[:status] }
+      end
+
+      def case_classifications_data(data)
+        return [] unless data[:classifications]
+
+        [data[:classifications][:classification]].flatten
+      end
+
+      def case_documents_data(data)
+        return [] unless data[:documents]
+
+        [data[:documents][:document]].flatten
       end
     end
 

--- a/spec/fixtures/getcases_without_classifications.txt
+++ b/spec/fixtures/getcases_without_classifications.txt
@@ -1,0 +1,25 @@
+HTTP/1.1 200 OK
+content-type: text/xml;charset=UTF-8
+content-length: 1739
+
+<?xml version="1.0" encoding="UTF-8"?>
+<Cases>
+  <Case>
+    <CaseId>487347</CaseId>
+    <Type>Information request</Type>
+    <Label>IR - y</Label>
+    <RequestMethod>Online Form</RequestMethod>
+    <RequestDate>2021-02-15T16:42:19</RequestDate>
+    <Status>Some information sent but not all held</Status>
+    <Attributes>
+      <Details>y</Details>
+      <InformationWillBe>Embedded in the response</InformationWillBe>
+      <PublishInTheDisclosureLog>Yes</PublishInTheDisclosureLog>
+      <ReasonInformationNotHeld>t</ReasonInformationNotHeld>
+      <SuitableForPublicationScheme>Yes</SuitableForPublicationScheme>
+    </Attributes>
+    <Documents>
+      <Document Id="D225851" Name="Response (some not held)" Category="General upload" Type="application/pdf" Source="Document" DocumentDate="2021-02-15T16:43:11"><![CDATA[https://uatportal.icasework.com/servlet/servlets.getImg?ref=D225851&bin=Y&auth=0&db=UJzFimNH5H4%3D&access_token=773WgblkSUxU7tva_uAQRK77bUD4lDfgfes_mz3uPHwZNu3ucP5OXsYgCtvDCvYz.AJAhd9_B7RiK45ojg4Lilw%3D%3D]]></Document>
+    </Documents>
+  </Case>
+</Cases>

--- a/spec/fixtures/getcases_without_documents.txt
+++ b/spec/fixtures/getcases_without_documents.txt
@@ -1,0 +1,27 @@
+HTTP/1.1 200 OK
+content-type: text/xml;charset=UTF-8
+content-length: 1739
+
+<?xml version="1.0" encoding="UTF-8"?>
+<Cases>
+  <Case>
+    <CaseId>487347</CaseId>
+    <Type>Information request</Type>
+    <Label>IR - y</Label>
+    <RequestMethod>Online Form</RequestMethod>
+    <RequestDate>2021-02-15T16:42:19</RequestDate>
+    <Status>Some information sent but not all held</Status>
+    <Attributes>
+      <Details>y</Details>
+      <InformationWillBe>Embedded in the response</InformationWillBe>
+      <PublishInTheDisclosureLog>Yes</PublishInTheDisclosureLog>
+      <ReasonInformationNotHeld>t</ReasonInformationNotHeld>
+      <SuitableForPublicationScheme>Yes</SuitableForPublicationScheme>
+    </Attributes>
+    <Classifications>
+      <Classification Group="About the council">Budgets spending and performance</Classification>
+      <Classification Group="Licensing and regulation">Animal licensing</Classification>
+      <Classification Group="Leisure and culture">Libraries</Classification>
+    </Classifications>
+  </Case>
+</Cases>

--- a/spec/icasework/case_spec.rb
+++ b/spec/icasework/case_spec.rb
@@ -50,6 +50,24 @@ RSpec.describe Icasework::Case do
       it { is_expected.to all(be_an(described_class)) }
       it { expect(cases.count).to eq 2 }
     end
+
+    context 'without classifications' do
+      let(:response) do
+        File.new('spec/fixtures/getcases_without_classifications.txt')
+      end
+
+      it { is_expected.to be_an Array }
+      it { is_expected.to all(be_an(described_class)) }
+    end
+
+    context 'without documents' do
+      let(:response) do
+        File.new('spec/fixtures/getcases_without_documents.txt')
+      end
+
+      it { is_expected.to be_an Array }
+      it { is_expected.to all(be_an(described_class)) }
+    end
   end
 
   describe '.create' do


### PR DESCRIPTION
Prevent errors when case data doesn't have classifications or documents.

Fixes #119