### PR TITLE
Specify REXML gem in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
       nokogiri (~> 1.0)
       pdf-reader (~> 2.4.0)
       rest-client (~> 2.1.0)
+      rexml (~> 3.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/icasework.gemspec
+++ b/icasework.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri', '~> 1.0'
   spec.add_dependency 'pdf-reader', '~> 2.4.0'
   spec.add_dependency 'rest-client', '~> 2.1.0'
+  spec.add_dependency 'rexml', '~> 3.4.0'
 end


### PR DESCRIPTION
Specify REXML gem in gemspec

REXML, although bundled with Ruby core in Ruby 3+, is not a standard gem
and needs to be explicitly required. While it's available in development
through dev dependencies, adding it directly to the gemspec ensures
availability across all environments including production.