### PR TITLE
Fix tests under Ruby 3+

### DIFF
--- a/spec/icasework/document_spec.rb
+++ b/spec/icasework/document_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Icasework::Document do
   end
 
   describe '#find' do
-    subject(:document) { described_class.find(payload) }
+    subject(:document) { described_class.find(**payload) }
 
     before do
       allow(described_class).to receive(:where).and_return(


### PR DESCRIPTION
In Ruby 3, you must explicitly use the double splat operator (`**`) to convert a Hash into keyword arguments. Without it, the Hash is treated as a single positional argument.